### PR TITLE
changing umask now only for non-root users

### DIFF
--- a/etc/profile.d/baseimage.sh
+++ b/etc/profile.d/baseimage.sh
@@ -1,2 +1,4 @@
 # File mode creation mask
-umask 0077
+if [[ $EUID -ne 0 ]]; then
+    umask 0077
+fi


### PR DESCRIPTION
@kzidane I realized that setting umask to 0022 for everyone, including root, breaks commands like `pip install foo`, since root is the only one that ends up being able to access the files, so you then have to fix with `chmod` manually.

Will this change break cs50/ecs?