### PR TITLE
Update baseimage.sh to set umask to 0077 only for non-root users

### DIFF
--- a/etc/profile.d/baseimage.sh
+++ b/etc/profile.d/baseimage.sh
@@ -1,2 +1,4 @@
 # File mode creation mask
-umask 0077
+if [ "$(id -u)" != "0" ]; then
+    umask 0077
+fi


### PR DESCRIPTION
@kzidane might this break anything? I'm not sure why I set it forcibly for all users, since Ubuntu's default for root is 0022, which isn't wise to override, since then commands like `pip` end up installing packages that are readable only by root.

This change mirrors what we do in the IDE, https://github.com/cs50/ide50/blob/develop/files/etc/profile.d/ide50.sh.